### PR TITLE
fix: update azure dogfood registration

### DIFF
--- a/msitask-df.yaml
+++ b/msitask-df.yaml
@@ -4,7 +4,7 @@ steps:
     cache: enabled
   - push:
       - $Registry/hello-world:$ID
-  - cmd: az cloud register -n dogfood --endpoint-active-directory https://login.windows-ppe.net --endpoint-active-directory-graph-resource-id https://graph.ppe.windows.net/ --endpoint-active-directory-resource-id https://management.core.windows.net/ --endpoint-gallery https://current.gallery.azure-test.net/ --endpoint-management https://management.core.windows.net/ --endpoint-resource-manager https://api-dogfood.resources.windows-int.net/ --suffix-storage-endpoint core.test-cint.azure-test.net --suffix-keyvault-dns vault.azure-int.net
+  - cmd: az cloud register -n dogfood --endpoint-active-directory https://login.windows-ppe.net --endpoint-active-directory-graph-resource-id https://graph.ppe.windows.net/ --endpoint-active-directory-resource-id https://management.core.windows.net/ --endpoint-gallery https://current.gallery.azure-test.net/ --endpoint-management https://management.core.windows.net/ --endpoint-resource-manager https://api-dogfood.resources.windows-int.net/ --suffix-storage-endpoint core.test-cint.azure-test.net --suffix-keyvault-dns .vault-int.azure-int.net --suffix-acr-login-server-endpoint .azurecr-test.io --endpoint-sql-management "https://management.core.windows.net:8443/"
   - cmd: az cloud set -n dogfood
   - cmd: az login --identity
   - cmd: az acr repository show-tags -n $RegistryName --repository hello-world


### PR DESCRIPTION
TaskBVT dogfood fails because of the following error:
```
Successfully executed container: acb_step_4
Executing step ID: acb_step_5. Timeout(sec): 600, Working directory: '', Network: 'acb_default_network'
Launching container with name: acb_step_5
ERROR: The suffix 'acr_login_server_endpoint' for this cloud is not set but is used.
/acb/home/.azure/clouds.config may be corrupt or invalid.
Resolve the error or delete this file and try again.
Container failed during run: acb_step_5. No retries remaining.
failed to run step ID: acb_step_5: exit status 1
```
Just FYI, this exception is thrown from [cloud.py#L161](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/cloud.py#L161).

I've tested that using my `https://github.com/yuehaoliang-microsoft/Task_BVT.git` as the context will fix the TaskBVT.